### PR TITLE
build(zcash-wasm): cargo aliases + indexmap/std shim

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,3 +12,11 @@ rustflags = [
 ]
 # wasm parallel build requires nightly:
 # RUSTUP_TOOLCHAIN=nightly cargo build --target wasm32-unknown-unknown -Zbuild-std=panic_abort,std
+
+[alias]
+# Rebuild just the .wasm for the parallel zafu bundle. Assumes nightly is
+# selected (RUSTUP_TOOLCHAIN=nightly or `cargo +nightly wasm-parallel`).
+wasm-parallel = "build -p zafu-wasm --target wasm32-unknown-unknown --release -Zbuild-std=panic_abort,std"
+
+# Single-threaded variant — stable-Rust OK, no -Z build-std.
+wasm-single = "build -p zafu-wasm --target wasm32-unknown-unknown --release --no-default-features"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7964,6 +7964,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "incrementalmerkletree 0.8.2",
+ "indexmap 1.9.3",
  "js-sys",
  "k256",
  "orchard 0.12.0",

--- a/crates/zcash-wasm/Cargo.toml
+++ b/crates/zcash-wasm/Cargo.toml
@@ -30,6 +30,12 @@ zip32 = { version = "0.2", default-features = false }
 incrementalmerkletree = { version = "0.8", features = ["legacy-api"] }
 hex = "0.4"
 
+# force indexmap's `std` feature across the dep graph so halo2_proofs
+# (which pulls indexmap with default-features = false) can use
+# IndexMap::new() — otherwise `has_std` cfg isn't set under `-Z build-std`
+# and the build fails with "struct takes 3 generic arguments".
+indexmap = { version = "1", features = ["std"] }
+
 # note encryption (no heavy circuit deps)
 zcash_note_encryption = "0.4"
 


### PR DESCRIPTION
- Add cargo aliases in .cargo/config.toml: `wasm-parallel` (needs +nightly) and `wasm-single` so the parallel zcash-wasm build recipe isn't opaque folklore. Consumers run `cargo +nightly wasm-parallel` to produce the .wasm.
- Force indexmap/std feature in zafu-wasm's Cargo.toml — newer nightlies don't set indexmap's `has_std` cfg under `-Z build-std`, so halo2_proofs's `IndexMap::new()` won't compile. Build-time unification only, no runtime effect.